### PR TITLE
Allow users to toggle notification sounds from a vscode setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,11 +34,14 @@ const activePids = async (parentPid, tty) => {
 };
 
 const sendNotification = (window, command, start) => {
+  const notificationSounds = vscode.workspace.getConfiguration('background-terminal-notifier').get('notificationSounds') || false;
+
   notifier.notify({
     title: "A command completed!",
     message: command,
     timeout: 100,
-    closeLabel: 'Ok'
+    closeLabel: 'Ok',
+    sound: notificationSounds
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "background-terminal-notifier",
 	"displayName": "Background Terminal Notifier",
 	"description": "Shows a notification when a terminal command completes in the background",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"publisher": "jaredly",
 	"engines": {
 		"vscode": "^1.30.0"
@@ -22,6 +22,12 @@
 					"title": "Poll frequency",
 					"type": "number",
 					"description": "Check for command completion every [n] seconds."
+				},
+				"background-terminal-notifier.notificationSounds": {
+					"default": false,
+					"title": "Notification Sounds",
+					"type": "boolean",
+					"description": "Toggle sound for terminal notifications."
 				}
 			}
 		}


### PR DESCRIPTION
<img width="1069" alt="Screen Shot 2020-04-16 at 9 36 02 PM" src="https://user-images.githubusercontent.com/1479977/79532601-7b124c80-802a-11ea-8bc8-cb04a6d979a2.png">
<img width="1069" alt="Screen Shot 2020-04-16 at 9 36 20 PM" src="https://user-images.githubusercontent.com/1479977/79532604-7c437980-802a-11ea-9752-137abd901932.png">

Notification window working after setting the toggle to true, this time it emits a sound.
<img width="354" alt="Screen Shot 2020-04-16 at 9 37 11 PM" src="https://user-images.githubusercontent.com/1479977/79532605-7c437980-802a-11ea-9f05-83d33299f241.png">
