### PR TITLE
Windows compatible (fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.vsix
+.vscode-test/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
 	"name": "background-terminal-notifier",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "background-terminal-notifier",
-			"version": "1.0.4",
+			"version": "1.0.5",
 			"hasInstallScript": true,
 			"dependencies": {
 				"node-notifier": "^6.0.0",
-				"ps-node": "^0.1.6"
+				"ps-list": "^7.2.0"
 			},
 			"devDependencies": {
-				"vscode": "^1.1.30"
+				"vscode": "^1.1.37"
 			},
 			"engines": {
 				"vscode": "^1.30.0"
@@ -79,11 +79,6 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
-		},
-		"node_modules/connected-domain": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/connected-domain/-/connected-domain-1.0.0.tgz",
-			"integrity": "sha512-lHlohUiJxlpunvDag2Y0pO20bnvarMjnrdciZeuJUqRwrf/5JHNhdpiPIr5GQ8IkqrFj5TDMQwcCjblGo1oeuA=="
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -394,12 +389,15 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/ps-node": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/ps-node/-/ps-node-0.1.6.tgz",
-			"integrity": "sha512-w7QJhUTbu70hpDso0YXDRNKCPNuchV8UTUZsAv0m7Qj5g85oHOJfr9drA1EjvK4nQK/bG8P97W4L6PJ3IQLoOA==",
-			"dependencies": {
-				"table-parser": "^0.1.3"
+		"node_modules/ps-list": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/ps-list/-/ps-list-7.2.0.tgz",
+			"integrity": "sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/semver": {
@@ -445,14 +443,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/table-parser": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/table-parser/-/table-parser-0.1.3.tgz",
-			"integrity": "sha512-LCYeuvqqoPII3lzzYaXKbC3Forb+d2u4bNwhk/9FlivuGRxPE28YEWAYcujeSlLLDlMfvy29+WPybFJZFiKMYg==",
-			"dependencies": {
-				"connected-domain": "^1.0.0"
 			}
 		},
 		"node_modules/vscode": {
@@ -617,11 +607,6 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
-		},
-		"connected-domain": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/connected-domain/-/connected-domain-1.0.0.tgz",
-			"integrity": "sha512-lHlohUiJxlpunvDag2Y0pO20bnvarMjnrdciZeuJUqRwrf/5JHNhdpiPIr5GQ8IkqrFj5TDMQwcCjblGo1oeuA=="
 		},
 		"debug": {
 			"version": "4.3.4",
@@ -872,13 +857,10 @@
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true
 		},
-		"ps-node": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/ps-node/-/ps-node-0.1.6.tgz",
-			"integrity": "sha512-w7QJhUTbu70hpDso0YXDRNKCPNuchV8UTUZsAv0m7Qj5g85oHOJfr9drA1EjvK4nQK/bG8P97W4L6PJ3IQLoOA==",
-			"requires": {
-				"table-parser": "^0.1.3"
-			}
+		"ps-list": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/ps-list/-/ps-list-7.2.0.tgz",
+			"integrity": "sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ=="
 		},
 		"semver": {
 			"version": "5.6.0",
@@ -914,14 +896,6 @@
 			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
-			}
-		},
-		"table-parser": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/table-parser/-/table-parser-0.1.3.tgz",
-			"integrity": "sha512-LCYeuvqqoPII3lzzYaXKbC3Forb+d2u4bNwhk/9FlivuGRxPE28YEWAYcujeSlLLDlMfvy29+WPybFJZFiKMYg==",
-			"requires": {
-				"connected-domain": "^1.0.0"
 			}
 		},
 		"vscode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "1.0.4",
 			"hasInstallScript": true,
 			"dependencies": {
-				"node-notifier": "^6.0.0"
+				"node-notifier": "^6.0.0",
+				"ps-node": "^0.1.6"
 			},
 			"devDependencies": {
 				"vscode": "^1.1.30"
@@ -78,6 +79,11 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
+		},
+		"node_modules/connected-domain": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/connected-domain/-/connected-domain-1.0.0.tgz",
+			"integrity": "sha512-lHlohUiJxlpunvDag2Y0pO20bnvarMjnrdciZeuJUqRwrf/5JHNhdpiPIr5GQ8IkqrFj5TDMQwcCjblGo1oeuA=="
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -388,6 +394,14 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/ps-node": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/ps-node/-/ps-node-0.1.6.tgz",
+			"integrity": "sha512-w7QJhUTbu70hpDso0YXDRNKCPNuchV8UTUZsAv0m7Qj5g85oHOJfr9drA1EjvK4nQK/bG8P97W4L6PJ3IQLoOA==",
+			"dependencies": {
+				"table-parser": "^0.1.3"
+			}
+		},
 		"node_modules/semver": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -431,6 +445,14 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/table-parser": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/table-parser/-/table-parser-0.1.3.tgz",
+			"integrity": "sha512-LCYeuvqqoPII3lzzYaXKbC3Forb+d2u4bNwhk/9FlivuGRxPE28YEWAYcujeSlLLDlMfvy29+WPybFJZFiKMYg==",
+			"dependencies": {
+				"connected-domain": "^1.0.0"
 			}
 		},
 		"node_modules/vscode": {
@@ -595,6 +617,11 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
+		},
+		"connected-domain": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/connected-domain/-/connected-domain-1.0.0.tgz",
+			"integrity": "sha512-lHlohUiJxlpunvDag2Y0pO20bnvarMjnrdciZeuJUqRwrf/5JHNhdpiPIr5GQ8IkqrFj5TDMQwcCjblGo1oeuA=="
 		},
 		"debug": {
 			"version": "4.3.4",
@@ -845,6 +872,14 @@
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true
 		},
+		"ps-node": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/ps-node/-/ps-node-0.1.6.tgz",
+			"integrity": "sha512-w7QJhUTbu70hpDso0YXDRNKCPNuchV8UTUZsAv0m7Qj5g85oHOJfr9drA1EjvK4nQK/bG8P97W4L6PJ3IQLoOA==",
+			"requires": {
+				"table-parser": "^0.1.3"
+			}
+		},
 		"semver": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -879,6 +914,14 @@
 			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
+			}
+		},
+		"table-parser": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/table-parser/-/table-parser-0.1.3.tgz",
+			"integrity": "sha512-LCYeuvqqoPII3lzzYaXKbC3Forb+d2u4bNwhk/9FlivuGRxPE28YEWAYcujeSlLLDlMfvy29+WPybFJZFiKMYg==",
+			"requires": {
+				"connected-domain": "^1.0.0"
 			}
 		},
 		"vscode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,177 +1,566 @@
 {
-	"name": "hello-world",
-	"version": "0.0.1",
-	"lockfileVersion": 1,
+	"name": "background-terminal-notifier",
+	"version": "1.0.4",
+	"lockfileVersion": 2,
 	"requires": true,
-	"dependencies": {
-		"@types/mocha": {
-			"version": "2.2.48",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
-			"integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
-			"dev": true
-		},
-		"@types/node": {
-			"version": "8.10.39",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.39.tgz",
-			"integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA==",
-			"dev": true
-		},
-		"ajv": {
-			"version": "6.6.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
-			"integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
-			"dev": true,
-			"requires": {
-				"fast-deep-equal": "^2.0.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+	"packages": {
+		"": {
+			"name": "background-terminal-notifier",
+			"version": "1.0.4",
+			"hasInstallScript": true,
+			"dependencies": {
+				"node-notifier": "^6.0.0"
+			},
+			"devDependencies": {
+				"vscode": "^1.1.30"
+			},
+			"engines": {
+				"vscode": "^1.30.0"
 			}
 		},
-		"ansi-cyan": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
-			"integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+		"node_modules/@tootallnate/once": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true,
-			"requires": {
-				"ansi-wrap": "0.1.0"
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"ansi-red": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-			"integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+		"node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"dev": true,
-			"requires": {
-				"ansi-wrap": "0.1.0"
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
 			}
 		},
-		"ansi-wrap": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-			"dev": true
-		},
-		"append-buffer": {
+		"node_modules/balanced-match": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
-			"integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
-			"dev": true,
-			"requires": {
-				"buffer-equal": "^1.0.0"
-			}
-		},
-		"arr-diff": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-			"integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
-			"dev": true,
-			"requires": {
-				"arr-flatten": "^1.0.1",
-				"array-slice": "^0.2.3"
-			}
-		},
-		"arr-flatten": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
-		"arr-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
-			"integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
 		},
-		"array-differ": {
+		"node_modules/buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"node_modules/commander": {
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+			"dev": true
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
+		},
+		"node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"dev": true
+		},
+		"node_modules/es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+			"dev": true,
+			"dependencies": {
+				"es6-promise": "^4.0.3"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
-		"array-slice": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-			"integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
-			"dev": true
-		},
-		"array-union": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+		"node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
-			"requires": {
-				"array-uniq": "^1.0.1"
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"array-uniq": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+		"node_modules/growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.x"
+			}
+		},
+		"node_modules/growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+		},
+		"node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA==",
+			"dev": true,
+			"bin": {
+				"he": "bin/he"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+			"dev": true,
+			"dependencies": {
+				"@tootallnate/once": "1",
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
-		"arrify": {
+		"node_modules/is-wsl": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+			"integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
+			"dev": true
+		},
+		"node_modules/mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
+			"deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+			"dev": true,
+			"dependencies": {
+				"minimist": "0.0.8"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/mocha": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+			"dev": true,
+			"dependencies": {
+				"browser-stdout": "1.3.1",
+				"commander": "2.15.1",
+				"debug": "3.1.0",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.2",
+				"growl": "1.10.5",
+				"he": "1.1.1",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"supports-color": "5.4.0"
+			},
+			"bin": {
+				"_mocha": "bin/_mocha",
+				"mocha": "bin/mocha"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/mocha/node_modules/debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/mocha/node_modules/glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/mocha/node_modules/minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/mocha/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true
+		},
+		"node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
+		"node_modules/node-notifier": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
+			"integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
+			"dependencies": {
+				"growly": "^1.3.0",
+				"is-wsl": "^2.1.1",
+				"semver": "^6.3.0",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.1"
+			}
+		},
+		"node_modules/node-notifier/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-			"dev": true
-		},
-		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true,
-			"requires": {
-				"safer-buffer": "~2.1.0"
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+		"node_modules/semver": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.9",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+			"dev": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/vscode": {
+			"version": "1.1.37",
+			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
+			"integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
+			"deprecated": "This package is deprecated in favor of @types/vscode and vscode-test. For more information please read: https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.1.2",
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "^5.0.0",
+				"mocha": "^5.2.0",
+				"semver": "^5.4.1",
+				"source-map-support": "^0.5.0",
+				"vscode-test": "^0.4.1"
+			},
+			"bin": {
+				"vscode-install": "bin/install"
+			},
+			"engines": {
+				"node": ">=8.9.3"
+			}
+		},
+		"node_modules/vscode-test": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
+			"integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+			"deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
+			"dev": true,
+			"dependencies": {
+				"http-proxy-agent": "^2.1.0",
+				"https-proxy-agent": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.9.3"
+			}
+		},
+		"node_modules/vscode-test/node_modules/agent-base": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"dev": true,
+			"dependencies": {
+				"es6-promisify": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/vscode-test/node_modules/debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/vscode-test/node_modules/http-proxy-agent": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "4",
+				"debug": "3.1.0"
+			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/vscode-test/node_modules/https-proxy-agent": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^4.3.0",
+				"debug": "^3.1.0"
+			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/vscode-test/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true
 		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+		"node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true
+		}
+	},
+	"dependencies": {
+		"@tootallnate/once": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true
 		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
-		},
-		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-			"dev": true
+		"agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"requires": {
+				"debug": "4"
+			}
 		},
 		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
-		},
-		"bcrypt-pbkdf": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dev": true,
-			"requires": {
-				"tweetnacl": "^0.14.3"
-			}
-		},
-		"block-stream": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-			"dev": true,
-			"requires": {
-				"inherits": "~2.0.0"
-			}
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -184,21 +573,9 @@
 			}
 		},
 		"browser-stdout": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-			"dev": true
-		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-			"dev": true
-		},
-		"buffer-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-			"integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
 		},
 		"buffer-from": {
@@ -207,353 +584,78 @@
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
 		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
-		},
-		"clone": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-			"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-			"dev": true
-		},
-		"clone-buffer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-			"dev": true
-		},
-		"clone-stats": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-			"dev": true
-		},
-		"cloneable-readable": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"process-nextick-args": "^2.0.0",
-				"readable-stream": "^2.3.5"
-			}
-		},
-		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-			"dev": true,
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
 		"commander": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
 			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
-		},
-		"convert-source-map": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.1.1"
-			}
-		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
-		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
 		},
 		"debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dev": true,
 			"requires": {
-				"ms": "2.0.0"
+				"ms": "2.1.2"
 			}
-		},
-		"deep-assign": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
-			"integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
-			"dev": true,
-			"requires": {
-				"is-obj": "^1.0.0"
-			}
-		},
-		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
-			"requires": {
-				"object-keys": "^1.0.12"
-			}
-		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
 		},
 		"diff": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
-		"duplexer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+		"es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
 			"dev": true
 		},
-		"duplexify": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-			"integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "^1.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0",
-				"stream-shift": "^1.0.0"
-			}
-		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dev": true,
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
-		},
-		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-			"dev": true,
-			"requires": {
-				"once": "^1.4.0"
+				"es6-promise": "^4.0.3"
 			}
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true
-		},
-		"event-stream": {
-			"version": "3.3.4",
-			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-			"dev": true,
-			"requires": {
-				"duplexer": "~0.1.1",
-				"from": "~0",
-				"map-stream": "~0.1.0",
-				"pause-stream": "0.0.11",
-				"split": "0.3",
-				"stream-combiner": "~0.0.4",
-				"through": "~2.3.1"
-			}
-		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true
-		},
-		"extend-shallow": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-			"integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
-			"dev": true,
-			"requires": {
-				"kind-of": "^1.1.0"
-			}
-		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
-		},
-		"fast-deep-equal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-			"dev": true
-		},
-		"fast-json-stable-stringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
-		},
-		"fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-			"dev": true,
-			"requires": {
-				"pend": "~1.2.0"
-			}
-		},
-		"flush-write-stream": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.4"
-			}
-		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
-		},
-		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
-			}
-		},
-		"from": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-			"dev": true
-		},
-		"fs-mkdirp-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
-			"integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.11",
-				"through2": "^2.0.3"
-			}
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
-		},
-		"fstream": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			}
-		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
 		},
 		"glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"glob-parent": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-			"dev": true,
-			"requires": {
-				"is-glob": "^3.1.0",
-				"path-dirname": "^1.0.0"
-			}
-		},
-		"glob-stream": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-			"integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
-			"dev": true,
-			"requires": {
-				"extend": "^3.0.0",
-				"glob": "^7.1.1",
-				"glob-parent": "^3.1.0",
-				"is-negated-glob": "^1.0.0",
-				"ordered-read-streams": "^1.0.0",
-				"pumpify": "^1.3.5",
-				"readable-stream": "^2.1.5",
-				"remove-trailing-separator": "^1.0.1",
-				"to-absolute-glob": "^2.0.0",
-				"unique-stream": "^2.0.2"
-			}
-		},
-		"graceful-fs": {
-			"version": "4.1.15",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-			"dev": true
-		},
 		"growl": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
 		"growly": {
@@ -561,254 +663,43 @@
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
 		},
-		"gulp-chmod": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
-			"integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
-			"dev": true,
-			"requires": {
-				"deep-assign": "^1.0.0",
-				"stat-mode": "^0.2.0",
-				"through2": "^2.0.0"
-			}
-		},
-		"gulp-filter": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
-			"integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
-			"dev": true,
-			"requires": {
-				"multimatch": "^2.0.0",
-				"plugin-error": "^0.1.2",
-				"streamfilter": "^1.0.5"
-			}
-		},
-		"gulp-gunzip": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
-			"integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
-			"dev": true,
-			"requires": {
-				"through2": "~0.6.5",
-				"vinyl": "~0.4.6"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"dev": true,
-					"requires": {
-						"readable-stream": ">=1.0.33-1 <1.1.0-0",
-						"xtend": ">=4.0.0 <4.1.0-0"
-					}
-				}
-			}
-		},
-		"gulp-remote-src-vscode": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.1.tgz",
-			"integrity": "sha512-mw4OGjtC/jlCWJFhbcAlel4YPvccChlpsl3JceNiB/DLJi24/UPxXt53/N26lgI3dknEqd4ErfdHrO8sJ5bATQ==",
-			"dev": true,
-			"requires": {
-				"event-stream": "3.3.4",
-				"node.extend": "^1.1.2",
-				"request": "^2.79.0",
-				"through2": "^2.0.3",
-				"vinyl": "^2.0.1"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-					"dev": true
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"dev": true,
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				}
-			}
-		},
-		"gulp-untar": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
-			"integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
-			"dev": true,
-			"requires": {
-				"event-stream": "~3.3.4",
-				"streamifier": "~0.1.1",
-				"tar": "^2.2.1",
-				"through2": "~2.0.3",
-				"vinyl": "^1.2.0"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
-				},
-				"replace-ext": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-					"dev": true,
-					"requires": {
-						"clone": "^1.0.0",
-						"clone-stats": "^0.0.1",
-						"replace-ext": "0.0.1"
-					}
-				}
-			}
-		},
-		"gulp-vinyl-zip": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.2.tgz",
-			"integrity": "sha512-wJn09jsb8PyvUeyFF7y7ImEJqJwYy40BqL9GKfJs6UGpaGW9A+N68Q+ajsIpb9AeR6lAdjMbIdDPclIGo1/b7Q==",
-			"dev": true,
-			"requires": {
-				"event-stream": "3.3.4",
-				"queue": "^4.2.1",
-				"through2": "^2.0.3",
-				"vinyl": "^2.0.2",
-				"vinyl-fs": "^3.0.3",
-				"yauzl": "^2.2.1",
-				"yazl": "^2.2.1"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-					"dev": true
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"dev": true,
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				}
-			}
-		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
-		},
-		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-			"dev": true,
-			"requires": {
-				"ajv": "^6.5.5",
-				"har-schema": "^2.0.0"
-			}
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
 		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-			"dev": true
-		},
-		"has-symbols": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true
 		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA==",
 			"dev": true
 		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+		"http-proxy-agent": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"@tootallnate/once": "1",
+				"agent-base": "6",
+				"debug": "4"
+			}
+		},
+		"https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"requires": {
+				"agent-base": "6",
+				"debug": "4"
 			}
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
@@ -816,100 +707,9 @@
 			}
 		},
 		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
-		},
-		"is": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
-			"integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
-			"dev": true
-		},
-		"is-absolute": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-			"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-			"dev": true,
-			"requires": {
-				"is-relative": "^1.0.0",
-				"is-windows": "^1.0.1"
-			}
-		},
-		"is-buffer": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
-		},
-		"is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
-		},
-		"is-glob": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-			"dev": true,
-			"requires": {
-				"is-extglob": "^2.1.0"
-			}
-		},
-		"is-negated-glob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
-			"dev": true
-		},
-		"is-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-			"dev": true
-		},
-		"is-relative": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-			"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-			"dev": true,
-			"requires": {
-				"is-unc-path": "^1.0.0"
-			}
-		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
-		},
-		"is-unc-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-			"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-			"dev": true,
-			"requires": {
-				"unc-path-regex": "^0.1.2"
-			}
-		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
-		},
-		"is-valid-glob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-			"integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
-			"dev": true
-		},
-		"is-windows": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
 		"is-wsl": {
@@ -917,114 +717,15 @@
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
 			"integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog=="
 		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
-		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
-		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true
-		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
-		},
-		"json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
-		},
-		"json-stable-stringify-without-jsonify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-			"dev": true
-		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
-			}
-		},
-		"kind-of": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-			"integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
-			"dev": true
-		},
-		"lazystream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.5"
-			}
-		},
-		"lead": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
-			"integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
-			"dev": true,
-			"requires": {
-				"flush-write-stream": "^1.0.2"
-			}
-		},
-		"map-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-			"dev": true
-		},
-		"mime-db": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
-			"dev": true
-		},
-		"mime-types": {
-			"version": "2.1.21",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
-			"dev": true,
-			"requires": {
-				"mime-db": "~1.37.0"
-			}
-		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
@@ -1033,36 +734,46 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
 			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
 			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
 		},
 		"mocha": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
 			"dev": true,
 			"requires": {
-				"browser-stdout": "1.3.0",
-				"commander": "2.11.0",
+				"browser-stdout": "1.3.1",
+				"commander": "2.15.1",
 				"debug": "3.1.0",
-				"diff": "3.3.1",
+				"diff": "3.5.0",
 				"escape-string-regexp": "1.0.5",
 				"glob": "7.1.2",
-				"growl": "1.10.3",
+				"growl": "1.10.5",
 				"he": "1.1.1",
+				"minimatch": "3.0.4",
 				"mkdirp": "0.5.1",
-				"supports-color": "4.4.0"
+				"supports-color": "5.4.0"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
 				"glob": {
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -1076,26 +787,29 @@
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
 					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"dev": true
 				}
 			}
 		},
 		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
-		},
-		"multimatch": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-			"dev": true,
-			"requires": {
-				"array-differ": "^1.0.0",
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"minimatch": "^3.0.0"
-			}
 		},
 		"node-notifier": {
 			"version": "6.0.0",
@@ -1116,292 +830,19 @@
 				}
 			}
 		},
-		"node.extend": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
-			"integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3",
-				"is": "^3.2.1"
-			}
-		},
-		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
-		},
-		"now-and-later": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
-			"integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
-			"dev": true,
-			"requires": {
-				"once": "^1.3.2"
-			}
-		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-			"dev": true
-		},
-		"object-keys": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-			"dev": true
-		},
-		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
-			}
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
 		},
-		"ordered-read-streams": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
-			"integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.1"
-			}
-		},
-		"path-dirname": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true
-		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
-		},
-		"pause-stream": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-			"dev": true,
-			"requires": {
-				"through": "~2.3"
-			}
-		},
-		"pend": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-			"dev": true
-		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
-		},
-		"plugin-error": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
-			"integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
-			"dev": true,
-			"requires": {
-				"ansi-cyan": "^0.1.1",
-				"ansi-red": "^0.1.1",
-				"arr-diff": "^1.0.1",
-				"arr-union": "^2.0.1",
-				"extend-shallow": "^1.1.2"
-			}
-		},
-		"process-nextick-args": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-			"dev": true
-		},
-		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
-			"dev": true
-		},
-		"pump": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-			"dev": true,
-			"requires": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
-		},
-		"pumpify": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-			"dev": true,
-			"requires": {
-				"duplexify": "^3.6.0",
-				"inherits": "^2.0.3",
-				"pump": "^2.0.0"
-			}
-		},
-		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
-		},
-		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-			"dev": true
-		},
-		"querystringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-			"integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
-			"dev": true
-		},
-		"queue": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
-			"integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
-			"dev": true,
-			"requires": {
-				"inherits": "~2.0.0"
-			}
-		},
-		"readable-stream": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-			"dev": true,
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"remove-bom-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
-			"integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
-			"dev": true,
-			"requires": {
-				"is-buffer": "^1.1.5",
-				"is-utf8": "^0.2.1"
-			}
-		},
-		"remove-bom-stream": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
-			"integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
-			"dev": true,
-			"requires": {
-				"remove-bom-buffer": "^3.0.0",
-				"safe-buffer": "^5.1.0",
-				"through2": "^2.0.3"
-			}
-		},
-		"remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
-		},
-		"replace-ext": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-			"dev": true
-		},
-		"request": {
-			"version": "2.88.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-			"dev": true,
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			}
-		},
-		"requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-			"dev": true
-		},
-		"resolve-options": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
-			"integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
-			"dev": true,
-			"requires": {
-				"value-or-function": "^3.0.0"
-			}
-		},
-		"rimraf": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-			"dev": true,
-			"requires": {
-				"glob": "^7.1.3"
-			}
-		},
-		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true
 		},
 		"semver": {
@@ -1431,381 +872,84 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"split": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-			"dev": true,
-			"requires": {
-				"through": "2"
-			}
-		},
-		"sshpk": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
-			"integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
-			"dev": true,
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
-		},
-		"stat-mode": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
-			"integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
-			"dev": true
-		},
-		"stream-combiner": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-			"dev": true,
-			"requires": {
-				"duplexer": "~0.1.1"
-			}
-		},
-		"stream-shift": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-			"dev": true
-		},
-		"streamfilter": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
-			"integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.2"
-			}
-		},
-		"streamifier": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
-			"integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
-			"dev": true
-		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
 		"supports-color": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-			"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 			"dev": true,
 			"requires": {
-				"has-flag": "^2.0.0"
-			}
-		},
-		"tar": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-			"dev": true,
-			"requires": {
-				"block-stream": "*",
-				"fstream": "^1.0.2",
-				"inherits": "2"
-			}
-		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
-		},
-		"through2": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "~2.3.6",
-				"xtend": "~4.0.1"
-			}
-		},
-		"through2-filter": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
-			"integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-			"dev": true,
-			"requires": {
-				"through2": "~2.0.0",
-				"xtend": "~4.0.0"
-			}
-		},
-		"to-absolute-glob": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-			"dev": true,
-			"requires": {
-				"is-absolute": "^1.0.0",
-				"is-negated-glob": "^1.0.0"
-			}
-		},
-		"to-through": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
-			"integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
-			"dev": true,
-			"requires": {
-				"through2": "^2.0.3"
-			}
-		},
-		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-			"dev": true,
-			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
-			}
-		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true
-		},
-		"typescript": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-			"integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
-			"dev": true
-		},
-		"unc-path-regex": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-			"dev": true
-		},
-		"unique-stream": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
-			"integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
-			"dev": true,
-			"requires": {
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"through2-filter": "^3.0.0"
-			}
-		},
-		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"dev": true,
-			"requires": {
-				"punycode": "^2.1.0"
-			}
-		},
-		"url-parse": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
-			"integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
-			"dev": true,
-			"requires": {
-				"querystringify": "^2.0.0",
-				"requires-port": "^1.0.0"
-			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
-		},
-		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-			"dev": true
-		},
-		"value-or-function": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
-			"integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
-			"dev": true
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
-			}
-		},
-		"vinyl": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-			"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-			"dev": true,
-			"requires": {
-				"clone": "^0.2.0",
-				"clone-stats": "^0.0.1"
-			}
-		},
-		"vinyl-fs": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
-			"integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
-			"dev": true,
-			"requires": {
-				"fs-mkdirp-stream": "^1.0.0",
-				"glob-stream": "^6.1.0",
-				"graceful-fs": "^4.0.0",
-				"is-valid-glob": "^1.0.0",
-				"lazystream": "^1.0.0",
-				"lead": "^1.0.0",
-				"object.assign": "^4.0.4",
-				"pumpify": "^1.3.5",
-				"readable-stream": "^2.3.3",
-				"remove-bom-buffer": "^3.0.0",
-				"remove-bom-stream": "^1.2.0",
-				"resolve-options": "^1.1.0",
-				"through2": "^2.0.0",
-				"to-through": "^2.0.0",
-				"value-or-function": "^3.0.0",
-				"vinyl": "^2.0.0",
-				"vinyl-sourcemap": "^1.1.0"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-					"dev": true
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"dev": true,
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				}
-			}
-		},
-		"vinyl-source-stream": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
-			"integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
-			"dev": true,
-			"requires": {
-				"through2": "^2.0.3",
-				"vinyl": "^0.4.3"
-			}
-		},
-		"vinyl-sourcemap": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
-			"integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
-			"dev": true,
-			"requires": {
-				"append-buffer": "^1.0.2",
-				"convert-source-map": "^1.5.0",
-				"graceful-fs": "^4.1.6",
-				"normalize-path": "^2.1.1",
-				"now-and-later": "^2.0.0",
-				"remove-bom-buffer": "^3.0.0",
-				"vinyl": "^2.0.0"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-					"dev": true
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"dev": true,
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				}
+				"has-flag": "^3.0.0"
 			}
 		},
 		"vscode": {
-			"version": "1.1.26",
-			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.26.tgz",
-			"integrity": "sha512-z1Nf5J38gjUFbuDCbJHPN6OJ//5EG+e/yHlh6ERxj/U9B2Qc3aiHaFr38/fee/GGnxvRw/XegLMOG+UJwKi/Qg==",
+			"version": "1.1.37",
+			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
+			"integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.2",
-				"gulp-chmod": "^2.0.0",
-				"gulp-filter": "^5.0.1",
-				"gulp-gunzip": "1.0.0",
-				"gulp-remote-src-vscode": "^0.5.1",
-				"gulp-untar": "^0.0.7",
-				"gulp-vinyl-zip": "^2.1.2",
-				"mocha": "^4.0.1",
-				"request": "^2.88.0",
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "^5.0.0",
+				"mocha": "^5.2.0",
 				"semver": "^5.4.1",
 				"source-map-support": "^0.5.0",
-				"url-parse": "^1.4.3",
-				"vinyl-fs": "^3.0.3",
-				"vinyl-source-stream": "^1.1.0"
+				"vscode-test": "^0.4.1"
+			}
+		},
+		"vscode-test": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
+			"integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+			"dev": true,
+			"requires": {
+				"http-proxy-agent": "^2.1.0",
+				"https-proxy-agent": "^2.2.1"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+					"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+					"dev": true,
+					"requires": {
+						"es6-promisify": "^5.0.0"
+					}
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"http-proxy-agent": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+					"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+					"dev": true,
+					"requires": {
+						"agent-base": "4",
+						"debug": "3.1.0"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "2.2.4",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+					"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^4.3.0",
+						"debug": "^3.1.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"dev": true
+				}
 			}
 		},
 		"which": {
@@ -1819,33 +963,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
-		},
-		"xtend": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-			"dev": true
-		},
-		"yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-			"dev": true,
-			"requires": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
-			}
-		},
-		"yazl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-			"integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-			"dev": true,
-			"requires": {
-				"buffer-crc32": "~0.2.3"
-			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"vscode": "^1.1.30"
 	},
 	"dependencies": {
-		"node-notifier": "^6.0.0"
+		"node-notifier": "^6.0.0",
+		"ps-node": "^0.1.6"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "background-terminal-notifier",
 	"displayName": "Background Terminal Notifier",
 	"description": "Shows a notification when a terminal command completes in the background",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"publisher": "jaredly",
 	"engines": {
 		"vscode": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"test": "node ./node_modules/vscode/bin/test"
 	},
 	"devDependencies": {
-		"vscode": "^1.1.25"
+		"vscode": "^1.1.30"
 	},
 	"dependencies": {
 		"node-notifier": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
 		"test": "node ./node_modules/vscode/bin/test"
 	},
 	"devDependencies": {
-		"vscode": "^1.1.30"
+		"vscode": "^1.1.37"
 	},
 	"dependencies": {
 		"node-notifier": "^6.0.0",
-		"ps-node": "^0.1.6"
+		"ps-list": "^7.2.0"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,9 @@
+const notifier = require("node-notifier");
+
+notifier.notify({
+  title: "start",
+  message: "test",
+  timeout: 3,
+  closeLabel: "Ok",
+  sound: true,
+});


### PR DESCRIPTION
https://github.com/jaredly/vscode-background-terminal-notifier/pull/8 didn't work on my PC (Windows 11) - `ps-node` was timing out even when I was running it by itself (maybe related to https://github.com/neekey/ps/issues/75)

I've tried `process-list` but it was giving me hard time with native prebuilds.

`ps-list` worked like a charm, but it doesn't provide `command` on Windows, which is fine by me.

Also notifications didn't work when command/message is undefined or an empty string, seems like it needs to have at least some content.

Also sounds didn't work at first, so I used `speaker` package, but then it turned out that I just disabled all notification sounds in system:
<img width="776" alt="image" src="https://user-images.githubusercontent.com/7756211/185831892-7cff71e6-461f-4008-8e72-7ebcf39511fd.png">

To build/install:
```
git clone https://github.com/Maxim-Mazurok/vscode-background-terminal-notifier
git checkout windows-compatible
npm i vscode@latest
npm ci
npm i -g vsce
vsce package
code --install-extension .\background-terminal-notifier-1.0.5.vsix
reload
```

Sometimes `vsce package` hangs, just Ctrl+C and proceed, it actually worked fine.

If `code --install-extension .\background-terminal-notifier-1.0.5.vsix` hangs - close VS Code and delete `c:\Users\{YourUserName}\.vscode\extensions\jaredly.background-terminal-notifier-1.0.5` manually