### PR TITLE
Allow users to set the notification timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,11 +35,12 @@ const activePids = async (parentPid, tty) => {
 
 const sendNotification = (window, command, start) => {
   const notificationSounds = vscode.workspace.getConfiguration('background-terminal-notifier').get('notificationSounds') || false;
+  const notificationTimeout = vscode.workspace.getConfiguration('background-terminal-notifier').get('notificationTimeout') || 100;
 
   notifier.notify({
     title: "A command completed!",
     message: command,
-    timeout: 100,
+    timeout: notificationTimeout,
     closeLabel: 'Ok',
     sound: notificationSounds
   });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
 					"title": "Notification Sounds",
 					"type": "boolean",
 					"description": "Toggle sound for terminal notifications."
+				},
+				"background-terminal-notifier.notificationTimeout": {
+					"default": 100,
+					"title": "Notification Timeout",
+					"type": "number",
+					"description": "How long to show the notification for, in milliseconds."
 				}
 			}
 		}


### PR DESCRIPTION
This addresses #13, providing users an easy way to make their notifications last longer or shorter.
